### PR TITLE
Allow serial port to be chosen, default to ttyS0

### DIFF
--- a/files/boot.py
+++ b/files/boot.py
@@ -24,8 +24,12 @@ try:
 
   f.close()
 
+  serialport = 'ttyS0'
+  if 'serialport' in nodesettings:
+    serialport = nodesettings['serialport']
+
   print "#!ipxe"
-  print "kernel http://" + nodesettings["kickstart_server_ip"] + "/ks/vmlinuz ks=http://" + nodesettings["kickstart_server_ip"] + "/ks/" + nodesettings["kickstart_profile"] + " edd=off ksdevice=bootif kssendmac console=ttyS1,115200 console=tty0 initrd=initrd.img"
+  print "kernel http://" + nodesettings["kickstart_server_ip"] + "/ks/vmlinuz ks=http://" + nodesettings["kickstart_server_ip"] + "/ks/" + nodesettings["kickstart_profile"] + " edd=off ksdevice=bootif kssendmac console=" + serialport + ",115200 console=tty0 initrd=initrd.img"
   print "initrd http://" + nodesettings["kickstart_server_ip"] + "/ks/initrd.img"
   print "boot"
 


### PR DESCRIPTION
Allow the serial port to be used during kickstart to be chosen.

To use something other than the default, the nodesettings files generated by ansible-role-pxe_config must be modified as well.
