### PR TITLE
Read PXE boot data from pxe_nodes.json

### DIFF
--- a/files/boot.py
+++ b/files/boot.py
@@ -2,6 +2,7 @@
 import sys
 import os
 import socket
+import json
 sys.stderr = sys.stdout
 print "Content-Type: text/plain"
 print
@@ -10,19 +11,10 @@ try:
   # from the name, e.g. c1-3 take c1-3
   hostname = socket.gethostbyaddr(os.environ["REMOTE_ADDR"])[0].split(".")[0]
 
-  os.stat("/var/www/provision/reinstall/" + hostname)
   os.remove("/var/www/provision/reinstall/" + hostname)
-  f = open("/var/www/provision/nodes/" + hostname + ".conf")
-  nodesettings = {}
-  for line in f.readlines():
-    #for every line, e.g. "key=value", set nodesettings["key"]="value"
-    #comment lines will throw an error, skip them
-    try:
-      nodesettings[line.split("=")[0]] = line.split("=")[1].strip()
-    except:
-      pass
-
-  f.close()
+  with open('/var/www/provision/nodes/pxe_nodes.json') as f:
+    j = json.load(f)
+  nodesettings = j[hostname]
 
   serialport = 'ttyS0'
   if 'serialport' in nodesettings:


### PR DESCRIPTION
This is step 2 in making the "create pxe node data" ansible task
faster. Step 1
( https://github.com/CSC-IT-Center-for-Science/ansible-role-pxe_config/pull/17
) creates pxe_nodes.json, step 2 uses that file in boot.py, and
finally in step 3 the creation of the individual node data files can
be removed.
