### PR TITLE
Log boot.py exceptions

### DIFF
--- a/files/boot.py
+++ b/files/boot.py
@@ -3,15 +3,27 @@ import sys
 import os
 import socket
 import json
+import syslog
 sys.stderr = sys.stdout
 print "Content-Type: text/plain"
 print
+
+def pxe_abort():
+  """Abort the PXE boot, continue with the next boot device in the BIOS boot order"""
+  print "#!ipxe"
+  print "exit"
+  sys.exit(0)
 
 try:
   # from the name, e.g. c1-3 take c1-3
   hostname = socket.gethostbyaddr(os.environ["REMOTE_ADDR"])[0].split(".")[0]
 
-  os.remove("/var/www/provision/reinstall/" + hostname)
+  try:
+    os.remove("/var/www/provision/reinstall/" + hostname)
+  except OSError as e:
+    syslog.syslog(syslog.LOG_INFO, str(e))
+    pxe_abort()
+
   with open('/var/www/provision/nodes/pxe_nodes.json') as f:
     j = json.load(f)
   nodesettings = j[hostname]
@@ -25,6 +37,6 @@ try:
   print "initrd http://" + nodesettings["kickstart_server_ip"] + "/ks/initrd.img"
   print "boot"
 
-except:
-   print "#!ipxe"
-   print "exit"
+except Exception as e:
+  syslog.syslog(syslog.LOG_ERR, str(e))
+  pxe_abort()


### PR DESCRIPTION
If boot.py fails with an exception, log it to syslog. In case the
exception is failing to remove the hostname file, it just means the
node isn't marked for reinstallation, so in this case log severity is
INFO. In case some other exception occurs, it's probably a more
serious error, and in that case the severity is ERR.
